### PR TITLE
Remove unused cookies permission from the manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,8 +6,7 @@
     "author": "fraser.chapman@gmail.com",
     "permissions": [
         "storage",
-        "activeTab",
-        "cookies"
+        "activeTab"
     ],
     "icons": {
         "16": "img/disable16.png",


### PR DESCRIPTION
I got this email from Google regarding narrowing the permissions on the extension. 

> Action Required: xdebug extension Requires Changes to Comply with Chrome Web Store Policy
> Use of permissions:

> Violation reference ID: [Purple Potassium](https://developer.chrome.com/docs/webstore/troubleshooting/#excessive-permissions)
> Violation:
> Requesting but not using the following permission(s):
> cookies
> How to rectify: Remove the above permission(s)
Relevant section of the programme policy:
Request access to the narrowest permissions necessary to implement your product's features or services. Don't attempt to 'future proof' your product by requesting a permission that might benefit services or features that have not yet been implemented. [(learn more)](https://developer.chrome.com/docs/webstore/program-policies/permissions/)
Please make the necessary changes within 30 days in order to avoid removal.
> Once you have made these changes, you may submit and publish a new draft in the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/developer/dashboard).

The way cookies are (now) handled via the content script is with the native `document.cookie`.

As such so no code actually calls `chrome.cookies` so the `cookies` permission is unused and needs to be removed from the manifest. 
