### PR TITLE
Version 1.0.2

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "xdebug extension",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A modern, dependency-free, extension for Xdebug",
     "author": "fraser.chapman@gmail.com",
     "permissions": [


### PR DESCRIPTION
I need to update the extension in the Chrome Web Store so I can transfer ownership over to JetBrains. 

I got a message - 

> We've received your request to transfer ownership of item ID: aoelhdemabeimdhedkidlnbkfhnhgnhm to another Chrome Web Store publisher account. Items with existing policy violations will not be transferred until the violations are rectified. Please make the necessary changes, and reply to this email so we can proceed with the transfer.

As it says in the request…

> “Only items that are published and without any violations will be transferred” (my emphasis) 

Obviously there is currently the warning for the cookie permission violation. i.e.

> Action Required: xdebug extension Requires Changes to Comply with Chrome Web Store Policy
Use of permissions:
> Violation reference ID: [Purple Potassium](https://developer.chrome.com/docs/webstore/troubleshooting/#excessive-permissions)
Violation:
Requesting but not using the following permission(s):
cookies

This is fixed in https://github.com/JetBrains/xdebug-extension/pull/5

So I think the best idea is for me to update the extension now to version 1.0.2 - then publish it to the various stores so the violation is removed and the transfer can happen. I will do the builds and release/tags and what not if everyone is happy with that? 
















