### PR TITLE
Use the name 'Xdebug Helper by JetBrains'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Xdebug Extension use](src/img/debug32.png) Xdebug Extension
+# ![Xdebug Helper use](src/img/debug32.png) Xdebug Helper by JetBrains
 
 A modern, dependency-free, cross-browser extension for Xdebug.
 
@@ -20,11 +20,11 @@ _* It may also work on other Chromium based browsers (Opera, Vivaldi, Brave, etc
 
 - Set custom IDE key, trace trigger, and profile triggers
 
-![Xdebug Extension options](img/xdebug-extension-options.png)
+![Xdebug Helper options](img/xdebug-extension-options.png)
 
 - Toggle debugging, profiling, and tracing
 
-![Xdebug Extension popup](img/xdebug-extension-popup.png)
+![Xdebug Helper popup](img/xdebug-extension-popup.png)
 
 ## Installation
 
@@ -49,14 +49,14 @@ From Mozilla Addons
 From source
 
 1) Clone the `xdebug-extension` repository
-2) Run the the build file: `. build.sh`
+2) Run the build file: `. build.sh`
 3) Navigate to `about:debugging#/runtime/this-firefox`
 4) Choose "Load Temporary Add-on…"
 5) Select the `xdebug-extension@[version].xpi` file in the `xdebug-extension/build` directory.
 
 Prebuilt
 
-1) Download the latest xpi file from [releases](https://github.com/FraserChapman/xdebug-extension/releases) e.g `xdebug-extension@1.0.0.xpi`
+1) Download the latest xpi file from [releases](https://github.com/JetBrains/xdebug-extension/releases) e.g `xdebug-extension@1.0.0.xpi`
 2) Click on "This Firefox"
 3) Choose "Load Temporary Add-on…"
 4) Select the `xdebug-extension@[version].xpi` file you downloaded in step one.

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ echo "Copied LICENSE to [$TMP_ZIP_DIR, $TMP_XPI_DIR]"
 
 
 # Firefox (xpi) manifest modifications
-if ! jq --indent 4 '. + {browser_specific_settings: {gecko: {id: "xdebug-extension@fraser"}}}' "$TMP_XPI_DIR/manifest.json" > "$TMP_XPI_DIR/manifest.json.tmp"; then
+if ! jq --indent 4 '. + {browser_specific_settings: {gecko: {id: "xdebug-helper@JetBrains"}}}' "$TMP_XPI_DIR/manifest.json" > "$TMP_XPI_DIR/manifest.json.tmp"; then
     echo "Failed to add browser-specific settings to Firefox manifest"
     exit 1
 fi
@@ -63,7 +63,7 @@ fi
 mv "$TMP_XPI_DIR/manifest.json.tmp" "$TMP_XPI_DIR/manifest.json"
 echo "Updated Firefox background script in manifest"
 
-( cd "$TMP_ZIP_DIR" && zip -T -u -r "$BUILD_DIR_ABSOLUTE/xdebug-extension@$VERSION.zip" * ) || { echo "Failed to create zip archive"; exit 1; }
-( cd "$TMP_XPI_DIR" && zip -T -u -r "$BUILD_DIR_ABSOLUTE/xdebug-extension@$VERSION.xpi" * ) || { echo "Failed to create xpi archive"; exit 1; }
+( cd "$TMP_ZIP_DIR" && zip -T -u -r "$BUILD_DIR_ABSOLUTE/xdebug-helper@$VERSION.zip" * ) || { echo "Failed to create zip archive"; exit 1; }
+( cd "$TMP_XPI_DIR" && zip -T -u -r "$BUILD_DIR_ABSOLUTE/xdebug-helper@$VERSION.xpi" * ) || { echo "Failed to create xpi archive"; exit 1; }
 
-echo "Build $VERSION complete: [$BUILD_DIR/xdebug-extension@$VERSION.xpi, $BUILD_DIR/xdebug-extension@$VERSION.zip]"
+echo "Build $VERSION complete: [$BUILD_DIR/xdebug-helper@$VERSION.xpi, $BUILD_DIR/xdebug-helper@$VERSION.zip]"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "name": "xdebug extension",
+    "name": "Xdebug Helper by JetBrains",
     "version": "1.0.2",
     "description": "A modern, dependency-free, extension for Xdebug",
     "author": "fraser.chapman@gmail.com",

--- a/src/options.html
+++ b/src/options.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xdebug Extension Options</title>
+    <title>Xdebug Helper Options</title>
     <link rel="stylesheet" type="text/css" href="options.css">
 </head>
 
 <body>
-    <h1>Xdebug Extension</h1>
+    <h1>Xdebug Helper by JetBrains</h1>
     <form>
         <fieldset>
             <legend>Options</legend>
@@ -33,7 +33,7 @@
     <div id="help">
         <h2>Shortcuts</h2>
     </div>
-    <a href="https://github.com/FraserChapman/xdebug-extension" target="_blank">
+    <a href="https://github.com/JetBrains/xdebug-extension" target="_blank">
         <img src="img/github25.png" alt="GitHub logo" width="25" height="25">
         xdebug-extension
     </a>

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xdebug Extension Popup</title>
+    <title>Xdebug Helper Popup</title>
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
-# Xdebug Extension Tests
+# Xdebug Helper by JetBrains Tests
 
-These tests use Puppeteer to automate interactions with the Xdebug extension.
+These tests use Puppeteer to automate interactions with the Xdebug Helper.
 By default the browser is run headless and the extension is tested against a local sever on port `8765`.
 
 ## Prerequisites
@@ -17,7 +17,7 @@ Ensure you have the following prerequisites installed:
 ```bash
 sudo apt update
 sudo apt upgrade
-sudo apt install nodejs  
+sudo apt install nodejs
 sudo snap install chromium
 ```
 
@@ -74,7 +74,7 @@ You can customize the test execution using the following environment variables.
 
 `BROWSER_PATH` Specifies the path to the browser executable. Defaults to `/snap/bin/chromium`.
 ```bash
-BROWSER_PATH=/usr/bin/google-chrome npm test 
+BROWSER_PATH=/usr/bin/google-chrome npm test
 ```
 ---
 
@@ -86,7 +86,7 @@ EXAMPLE_PAGE=https://example.com/ npm test
 
 `DEFAULT_KEY` Configures the default IDE key for the Xdebug extension. Defaults to `PHPSTORM`.
 ```bash
-DEFAULT_KEY=MY_CUSTOM_KEY npm test 
+DEFAULT_KEY=MY_CUSTOM_KEY npm test
 ```
 ---
 
@@ -118,11 +118,11 @@ DEV_TOOLS=true npm test
 
 ### Browser was not found at the configured executablePath
 
-Please verify that a compatible browser (like Chromium) is installed and accessible. 
+Please verify that a compatible browser (like Chromium) is installed and accessible.
 
 The expected default location is `/snap/bin/chromium`.
 
-If your browser is installed elsewhere, set the `BROWSER_PATH` environment variable before running the tests. For example: 
+If your browser is installed elsewhere, set the `BROWSER_PATH` environment variable before running the tests. For example:
 
 ```bash
 BROWSER_PATH=/path/to/your/browser npm test
@@ -130,7 +130,7 @@ BROWSER_PATH=/path/to/your/browser npm test
 
 ### Failed to launch the browser process! Missing X server or $DISPLAY
 
-If you are using a non-GUI distribution, such as in WSL/WSL2, you will need to set the `DISPLAY` environment variable. You can do this using the command: 
+If you are using a non-GUI distribution, such as in WSL/WSL2, you will need to set the `DISPLAY` environment variable. You can do this using the command:
 
 ```bash
 export DISPLAY=:0

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -7,6 +7,6 @@ module.exports = async function (globalConfig, projectConfig) {
 
     global.server = http.createServer(function (req, res) {
         res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end('<h1>Xdebug extension test page</h1>');
+        res.end('<h1>Xdebug Helper Test Page</h1>');
     }).listen(8765);
 }

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -12,7 +12,7 @@ async function getBrowser() {
         slowMo: config.slowMo,
         devtools: config.devtools,
         args: [
-            '--window-name=Xdebug Extension Tests',
+            '--window-name=Xdebug Helper Tests',
             '--window-size=800,600',
             '--no-first-run',
             `--disable-extensions-except=${config.extensionDir}`,


### PR DESCRIPTION
This will make more sense if the repository is also renamed to `xdebug-helper`, and a few more things will have to be changed than too. 

@pronskiy had emailed me about the naming, and I thought I'd go over it to also check for `Xdebug` vs `xdebug` in places.