### PR TITLE
Set domain on cookie

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -8,11 +8,9 @@ const setCookie = (name, value, days = 365) =>
 
 const getDomainForCookie = () => {
   const parts = window.location.hostname.split(".");
-  if (parts.length <= 1) {
-    return window.location.hostname;
-  }
-
-  return "." + parts.slice(-2).join(".");
+  return parts.length <= 1 ? 
+    window.location.hostname:
+    parts.slice(-2).join(".");
 };
 
 const getStatusMap = (settings) => {

--- a/src/content.js
+++ b/src/content.js
@@ -4,7 +4,16 @@ const getCookie = name =>
     document.cookie.split(';').find(cookie => cookie.trim().startsWith(`${name}=`))?.split('=')[1];
 
 const setCookie = (name, value, days = 365) =>
-    document.cookie = `${name}=${value};expires=${new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString()};path=/`;
+    document.cookie = `${name}=${value};expires=${new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString()};path=/;domain=${getDomainForCookie()}`;
+
+const getDomainForCookie = () => {
+  const parts = window.location.hostname.split(".");
+  if (parts.length <= 1) {
+    return window.location.hostname;
+  }
+
+  return "." + parts.slice(-2).join(".");
+};
 
 const getStatusMap = (settings) => {
     const { xdebugDebugTrigger, xdebugTraceTrigger, xdebugProfileTrigger } = settings;

--- a/test/__TEST__/popup.test.js
+++ b/test/__TEST__/popup.test.js
@@ -1,6 +1,7 @@
 const {
     openPopup,
     openExamplePage,
+    getDomainForCookie
 } = require('../testUtils.js');
 
 describe('Popup Tests', () => {
@@ -25,11 +26,13 @@ describe('Popup Tests', () => {
         await popup.locator('label[for="debug"]').click();
 
         // Assert
-        const x = await page.waitForFunction(() => document.cookie);
+        await page.waitForFunction(() => document.cookie);
         const cookies = await global.browser.cookies();
-        const xdebugSessionCookie = cookies.find(cookie => cookie.name === 'XDEBUG_SESSION');
+        const testCookie = cookies.find(cookie => cookie.name === 'XDEBUG_SESSION');
+        const domain = await getDomainForCookie(page);
         expect(cookies.length).toBe(1);
-        expect(xdebugSessionCookie.value).toBe(config.defaultKey);
+        expect(testCookie.domain).toBe(domain);
+        expect(testCookie.value).toBe(config.defaultKey);
         await page.close();
     });
 
@@ -44,9 +47,11 @@ describe('Popup Tests', () => {
         // Assert
         await page.waitForFunction(() => document.cookie);
         const cookies = await global.browser.cookies();
-        const xdebugTraceCookie = cookies.find(cookie => cookie.name === 'XDEBUG_TRACE');
+        const testCookie = cookies.find(cookie => cookie.name === 'XDEBUG_TRACE');
+        const domain = await getDomainForCookie(page);
         expect(cookies.length).toBe(1);
-        expect(xdebugTraceCookie.value).toBe(config.defaultKey);
+        expect(testCookie.domain).toBe(domain);
+        expect(testCookie.value).toBe(config.defaultKey);
         await page.close();
     });
 
@@ -61,9 +66,11 @@ describe('Popup Tests', () => {
         // Assert
         await page.waitForFunction(() => document.cookie);
         const cookies = await global.browser.cookies();
-        const xdebugProfileCookie = cookies.find(cookie => cookie.name === 'XDEBUG_PROFILE');
+        const testCookie = cookies.find(cookie => cookie.name === 'XDEBUG_PROFILE');
+        const domain = await getDomainForCookie(page);
         expect(cookies.length).toBe(1);
-        expect(xdebugProfileCookie.value).toBe(config.defaultKey);
+        expect(testCookie.domain).toBe(domain);
+        expect(testCookie.value).toBe(config.defaultKey);
         await page.close();
     });
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "xdebug-extension-test",
-    "version": "1.0.1",
+    "name": "xdebug-helper-test",
+    "version": "1.0.3",
     "scripts": {
         "test": "jest",
         "watch": "jest --watch",

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -119,11 +119,9 @@ async function waitForStoredValue(page, key) {
 async function getDomainForCookie(page) {
     const hostname = await page.evaluate(() => window.location.hostname);
     const parts = hostname.split(".");
-    if (parts.length <= 1) {
-        return hostname;
-    }
-
-    return "." + parts.slice(-2).join(".");
+    return parts.length <= 1 ? 
+        hostname :
+        parts.slice(-2).join(".");
 }
 
 module.exports = {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -111,11 +111,27 @@ async function waitForStoredValue(page, key) {
     }, key);
 }
 
+/**
+ * Gets the domain string suitable for cookies, based on the current hostname.
+ * @param {puppeteer.Page} page The Puppeteer Page object representing the extension's page.
+ * @returns {Promise<string>} A Promise that resolves to the domain string.
+ */
+async function getDomainForCookie(page) {
+    const hostname = await page.evaluate(() => window.location.hostname);
+    const parts = hostname.split(".");
+    if (parts.length <= 1) {
+        return hostname;
+    }
+
+    return "." + parts.slice(-2).join(".");
+}
+
 module.exports = {
-    getBrowser,
-    getExtensionId,
-    openPopup,
-    openOptions,
-    openExamplePage,
-    waitForStoredValue,
+  getBrowser,
+  getExtensionId,
+  openPopup,
+  openOptions,
+  openExamplePage,
+  waitForStoredValue,
+  getDomainForCookie,
 };


### PR DESCRIPTION
Implements feature request https://github.com/JetBrains/xdebug-extension/issues/10

With a slight change, in that according to https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie, specifying a domain implicitly includes subdomains. Leading dots in domain names are now ignored by modern browsers, despite their historical significance. Refer to https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3.

While a leading dot was previously used to denote subdomain validity, RFC 6265 revised this behavior. Consequently, setting the `;domain=` attribute to the current page's domain directly is now the recommended approach.

tl;dr

Sets `domain=foo.bar` rather than `domain=.foo.bar`