### PR TITLE
Adds dark mode support to options and popup

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -4,17 +4,23 @@
   --light-label: #555;
   --light-form-bg: white;
   --light-link: #747474;
+  --light-save-button: #007bff;
+  --light-save-button-hover: #0056b3;
+  --light-clear-button: #888887;
+  --light-clear-button-hover: #5f5f5f;
+  --light-form-success: #9fff8a80;
 
-  --dark-bg: #2b2b2b;
+  --dark-bg: #1e1e1e;
   --dark-text: #f4f7fa;
   --dark-label: #e0e0e0;
-  --dark-form-bg: #555;
+  --dark-form-bg: #333;
   --dark-link: #e0e0e0;
+  --dark-save-button: #4a90e2;
+  --dark-save-button-hover: #357abd;
+  --dark-clear-button: #666;
+  --dark-clear-button-hover: #505050;
+  --dark-form-success: #3daf3d80;
 
-  --primary-button: #007bff;
-  --primary-button-hover: #0056b3;
-  --secondary-button: #888887;
-  --secondary-button-hover: #5f5f5f;
   --input-border: #ccc;
   --input-focus-border: #007bff;
   --kbd-bg: #eee;
@@ -32,6 +38,8 @@ body {
   height: 100vh;
   gap: 1em;
   transition: background-color 0.3s ease, color 0.3s ease;
+  background-color: var(--light-bg);
+  color: var(--light-text);
 }
 
 form {
@@ -41,11 +49,12 @@ form {
   width: 100%;
   max-width: 400px;
   transition: background-color 0.3s ease;
+  background: var(--light-form-bg);
 }
 
 form.success {
-  background-color: rgba(159, 255, 138, 0.5);
   transition: background-color 0.3s ease;
+  background: var(--light-form-success);
 }
 
 fieldset {
@@ -55,12 +64,9 @@ fieldset {
   border: 0;
 }
 
-legend {
-  text-align: center;
-}
-
 label {
   transition: color 0.3s ease;
+  color: var(--light-label);
 }
 
 input[type="text"] {
@@ -72,27 +78,11 @@ input[type="text"] {
 
 button {
   padding: 10px;
-  color: white;
   border: none;
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.3s ease;
-}
-
-button[type="submit"] {
-  background-color: var(--primary-button);
-}
-
-button[type="submit"]:hover {
-  background-color: var(--primary-button-hover);
-}
-
-button[type="reset"] {
-  background-color: var(--secondary-button);
-}
-
-button[type="reset"]:hover {
-  background-color: var(--secondary-button-hover);
+  color: white;
 }
 
 input[type="text"]:focus {
@@ -106,7 +96,7 @@ kbd {
   border: 1px solid var(--kbd-border);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
     0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-  color: #333;
+  color: var(--light-text);
   display: inline-block;
   font-weight: 700;
   line-height: 1;
@@ -119,6 +109,7 @@ a {
   align-items: center;
   text-decoration: none;
   transition: color 0.3s ease;
+  color: var(--light-link);
 }
 
 a img {
@@ -133,29 +124,23 @@ a img {
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease, color 0.3s ease;
+  background: var(--light-form-bg);
 }
 
-@media (prefers-color-scheme: light) {
-  body {
-    background-color: var(--light-bg);
-    color: var(--light-text);
-  }
+button[type="submit"] {
+  background-color: var(--light-save-button);
+}
 
-  form {
-    background: var(--light-form-bg);
-  }
+button[type="submit"]:hover {
+  background-color: var(--light-save-button-hover);
+}
 
-  label {
-    color: var(--light-label);
-  }
+button[type="reset"] {
+  background-color: var(--light-clear-button);
+}
 
-  #help {
-    background: var(--light-form-bg);
-  }
-
-  a {
-    color: var(--light-link);
-  }
+button[type="reset"]:hover {
+  background-color: var(--light-clear-button-hover);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -168,8 +153,28 @@ a img {
     background: var(--dark-form-bg);
   }
 
+  form.success {
+    background: var(--dark-form-success);
+  }
+
   label {
     color: var(--dark-label);
+  }
+
+  button[type="submit"] {
+    background-color: var(--dark-save-button);
+  }
+
+  button[type="submit"]:hover {
+    background-color: var(--dark-save-button-hover);
+  }
+
+  button[type="reset"] {
+    background-color: var(--dark-clear-button);
+  }
+
+  button[type="reset"]:hover {
+    background-color: var(--dark-clear-button-hover);
   }
 
   #help {

--- a/src/options.css
+++ b/src/options.css
@@ -1,114 +1,183 @@
+:root {
+  --light-bg: #f4f7fa;
+  --light-text: #333;
+  --light-label: #555;
+  --light-form-bg: white;
+  --light-link: #747474;
+
+  --dark-bg: #2b2b2b;
+  --dark-text: #f4f7fa;
+  --dark-label: #e0e0e0;
+  --dark-form-bg: #555;
+  --dark-link: #e0e0e0;
+
+  --primary-button: #007bff;
+  --primary-button-hover: #0056b3;
+  --secondary-button: #888887;
+  --secondary-button-hover: #5f5f5f;
+  --input-border: #ccc;
+  --input-focus-border: #007bff;
+  --kbd-bg: #eee;
+  --kbd-border: #b4b4b4;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f4f7fa;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    color: #333;
-    gap: 1em;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 1em;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 form {
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    width: 100%;
-    max-width: 400px;
-    transition: background-color .5s linear;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  transition: background-color 0.3s ease;
 }
 
 form.success {
-    transition: background-color .5s linear;
-    background-color: rgba(159, 255, 138, 0.5);
+  background-color: rgba(159, 255, 138, 0.5);
+  transition: background-color 0.3s ease;
 }
 
 fieldset {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    border: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  border: 0;
 }
 
 legend {
-    color: #444;
-    text-align: center;
+  text-align: center;
 }
 
 label {
-    color: #555;
+  transition: color 0.3s ease;
 }
 
 input[type="text"] {
-    padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+  padding: 8px;
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  transition: border-color 0.3s ease;
 }
 
 button {
-    padding: 10px;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+  padding: 10px;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
 }
 
 button[type="submit"] {
-    background-color: #007bff;
+  background-color: var(--primary-button);
 }
 
 button[type="submit"]:hover {
-    background-color: #0056b3;
+  background-color: var(--primary-button-hover);
 }
 
 button[type="reset"] {
-    background-color: #888887;
+  background-color: var(--secondary-button);
 }
 
 button[type="reset"]:hover {
-    background-color: #5f5f5f;
+  background-color: var(--secondary-button-hover);
 }
 
 input[type="text"]:focus {
-    outline: none;
-    border-color: #007bff;
+  outline: none;
+  border-color: var(--input-focus-border);
 }
 
 kbd {
-    background-color: #eee;
-    border-radius: 3px;
-    border: 1px solid #b4b4b4;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-    color: #333;
-    display: inline-block;
-    font-weight: 700;
-    line-height: 1;
-    padding: 2px 4px;
-    white-space: nowrap;
+  background-color: var(--kbd-bg);
+  border-radius: 3px;
+  border: 1px solid var(--kbd-border);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
+    0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+  color: #333;
+  display: inline-block;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  white-space: nowrap;
 }
 
 a {
-    color: #747474;
-    display: flex;
-    align-items: center;
-    text-decoration: none;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  transition: color 0.3s ease;
 }
 
 a img {
-    margin-right: 0.1em;
+  margin-right: 0.1em;
 }
 
 #help {
-    padding: 20px;
-    background: white;
-    color: #333;
-    width: 100%;
-    max-width: 400px;
-    text-align: center;
-    border-radius: 8px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background-color: var(--light-bg);
+    color: var(--light-text);
+  }
+
+  form {
+    background: var(--light-form-bg);
+  }
+
+  label {
+    color: var(--light-label);
+  }
+
+  #help {
+    background: var(--light-form-bg);
+  }
+
+  a {
+    color: var(--light-link);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: var(--dark-bg);
+    color: var(--dark-text);
+  }
+
+  form {
+    background: var(--dark-form-bg);
+  }
+
+  label {
+    color: var(--dark-label);
+  }
+
+  #help {
+    background: var(--dark-form-bg);
+    color: var(--dark-label);
+  }
+
+  a {
+    color: var(--dark-link);
+  }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -12,7 +12,6 @@
     <h1>Xdebug Extension</h1>
     <form>
         <fieldset>
-            <legend>Options</legend>
             <label for="debugtrigger">Debug Trigger or Xdebug Cloud Key</label>
             <input type="text" id="debugtrigger" placeholder="Debug trigger or Xdebug Cloud Key" value="YOUR-NAME">
             <label for="tracetrigger">Trace Trigger</label>

--- a/src/popup.css
+++ b/src/popup.css
@@ -5,7 +5,7 @@
   --light-radio-checked-bg: #9cf78c;
   --light-options-color: #8d8d8d;
 
-  --dark-bg: #2b2b2b;
+  --dark-bg: #1e1e1e;
   --dark-text: #e0e0e0;
   --dark-radio-bg: #444;
   --dark-radio-hover-bg: #555;
@@ -17,6 +17,7 @@ body {
   font-family: Arial, sans-serif;
   width: 100px;
   font-size: 0.8em;
+  color: var(--light-text);
 }
 
 form {
@@ -43,16 +44,19 @@ input[type="radio"] {
   margin: 0;
 }
 
-input[type="radio"] + label {
+input[type="radio"]+label {
   transition: background-color 0.3s ease;
+  background-color: var(--light-radio-bg);
 }
 
-input[type="radio"]:hover + label {
+input[type="radio"]:hover+label {
   transition: background-color 0.3s ease;
+  background-color: var(--light-radio-hover-bg);
 }
 
-input[type="radio"]:checked + label {
+input[type="radio"]:checked+label {
   transition: background-color 0.3s ease;
+  background-color: var(--light-radio-checked-bg);
 }
 
 #options {
@@ -60,28 +64,7 @@ input[type="radio"]:checked + label {
   text-decoration: none;
   text-align: center;
   transition: color 0.3s ease;
-}
-
-@media (prefers-color-scheme: light) {
-  body {
-    color: var(--light-text);
-  }
-
-  input[type="radio"] + label {
-    background-color: var(--light-radio-bg);
-  }
-
-  input[type="radio"]:hover + label {
-    background-color: var(--light-radio-hover-bg);
-  }
-
-  input[type="radio"]:checked + label {
-    background-color: var(--light-radio-checked-bg);
-  }
-
-  #options {
-    color: var(--light-options-color);
-  }
+  color: var(--light-options-color);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -90,15 +73,15 @@ input[type="radio"]:checked + label {
     color: var(--dark-text);
   }
 
-  input[type="radio"] + label {
+  input[type="radio"]+label {
     background-color: var(--dark-radio-bg);
   }
 
-  input[type="radio"]:hover + label {
+  input[type="radio"]:hover+label {
     background-color: var(--dark-radio-hover-bg);
   }
 
-  input[type="radio"]:checked + label {
+  input[type="radio"]:checked+label {
     background-color: var(--dark-radio-checked-bg);
   }
 

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,49 +1,108 @@
+:root {
+  --light-text: #2b2b2b;
+  --light-radio-bg: #ccc;
+  --light-radio-hover-bg: #ececec;
+  --light-radio-checked-bg: #9cf78c;
+  --light-options-color: #8d8d8d;
+
+  --dark-bg: #2b2b2b;
+  --dark-text: #e0e0e0;
+  --dark-radio-bg: #444;
+  --dark-radio-hover-bg: #555;
+  --dark-radio-checked-bg: #4caf50;
+  --dark-options-color: #a0a0a0;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    width: 100px;
-    font-size: 0.8em;
-    color: #2b2b2b;
+  font-family: Arial, sans-serif;
+  width: 100px;
+  font-size: 0.8em;
 }
 
 form {
-    display: flex;
-    flex-direction: column;
-    width: 100px;
-    gap: 0.2em;
+  display: flex;
+  flex-direction: column;
+  width: 100px;
+  gap: 0.2em;
 }
 
 form label {
-    display: flex;
-    align-items: center;
-    padding: 0.5em;
+  display: flex;
+  align-items: center;
+  padding: 0.5em;
 }
 
 form label img {
-    margin: 0 0.5em 0 0.5em;
+  margin: 0 0.5em 0 0.5em;
 }
 
 input[type="radio"] {
-    visibility: hidden;
-    height: 0;
-    width: 0;
-    margin: 0;
+  visibility: hidden;
+  height: 0;
+  width: 0;
+  margin: 0;
 }
 
-input[type="radio"]+label {
-    background-color: #ccc;
+input[type="radio"] + label {
+  transition: background-color 0.3s ease;
 }
 
-input[type="radio"]:hover+label {
-    background-color: #ececec;
+input[type="radio"]:hover + label {
+  transition: background-color 0.3s ease;
 }
 
-input[type="radio"]:checked+label {
-    background-color: #9cf78c;
+input[type="radio"]:checked + label {
+  transition: background-color 0.3s ease;
 }
 
 #options {
-    margin-top: 0.5em;
-    color: #8d8d8d;
-    text-decoration: none;
-    text-align: center;
+  margin-top: 0.5em;
+  text-decoration: none;
+  text-align: center;
+  transition: color 0.3s ease;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    color: var(--light-text);
+  }
+
+  input[type="radio"] + label {
+    background-color: var(--light-radio-bg);
+  }
+
+  input[type="radio"]:hover + label {
+    background-color: var(--light-radio-hover-bg);
+  }
+
+  input[type="radio"]:checked + label {
+    background-color: var(--light-radio-checked-bg);
+  }
+
+  #options {
+    color: var(--light-options-color);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: var(--dark-bg);
+    color: var(--dark-text);
+  }
+
+  input[type="radio"] + label {
+    background-color: var(--dark-radio-bg);
+  }
+
+  input[type="radio"]:hover + label {
+    background-color: var(--dark-radio-hover-bg);
+  }
+
+  input[type="radio"]:checked + label {
+    background-color: var(--dark-radio-checked-bg);
+  }
+
+  #options {
+    color: var(--dark-options-color);
+  }
 }


### PR DESCRIPTION
See https://github.com/JetBrains/xdebug-extension/issues/11

Adds dark mode support by leveraging the `@media (prefers-color-scheme: dark)` and `@media (prefers-color-scheme: light)` media queries, along with CSS variables. 

On a dark mode browser it looks like this...

![Screenshot 2025-03-11 123919](https://github.com/user-attachments/assets/0983dc69-b8a7-4650-a87c-d3cfffec51bb)

![Screenshot 2025-03-11 125207](https://github.com/user-attachments/assets/04db7580-6813-40bc-b92b-acc69ae07a4b)

Probably just need to tweak/agree on the actual colours for "light" and "dark" mode. 