### PR TITLE
Adds i18n support for options and popup

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper od JetBrains"
+  },
+  "options_title": {
+    "message": "Možnosti Xdebug Helper"
+  },
+  "options_debug_trigger": {
+    "message": "Spouštěč ladění nebo klíč Xdebug Cloud"
+  },
+  "options_trace_trigger": {
+    "message": "Spouštěč trasování"
+  },
+  "options_profile_trigger": {
+    "message": "Spouštěč profilování"
+  },
+  "options_clear": {
+    "message": "Vymazat"
+  },
+  "options_save": {
+    "message": "Uložit"
+  },
+  "options_shortcuts": {
+    "message": "Zkratky"
+  },
+  "options_execute_action": {
+    "message": "Provést akci"
+  },
+  "options_toggle_debug": {
+    "message": "Přepnout ladění"
+  },
+  "options_toggle_profile": {
+    "message": "Přepnout profilování"
+  },
+  "options_toggle_trace": {
+    "message": "Přepnout trasování"
+  },
+  "popup_title": {
+    "message": "Vyskakovací okno Xdebug Helper"
+  },
+  "popup_debug": {
+    "message": "Ladění"
+  },
+  "popup_profile": {
+    "message": "Profilování"
+  },
+  "popup_trace": {
+    "message": "Trasování"
+  },
+  "popup_disable": {
+    "message": "Zakázat"
+  },
+  "popup_options": {
+    "message": "Možnosti"
+  }
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper von JetBrains"
+  },
+  "options_title": {
+    "message": "Xdebug Helper-Optionen"
+  },
+  "options_debug_trigger": {
+    "message": "Debug-Trigger oder Xdebug Cloud-Schlüssel"
+  },
+  "options_trace_trigger": {
+    "message": "Trace-Trigger"
+  },
+  "options_profile_trigger": {
+    "message": "Profil-Trigger"
+  },
+  "options_clear": {
+    "message": "Löschen"
+  },
+  "options_save": {
+    "message": "Speichern"
+  },
+  "options_shortcuts": {
+    "message": "Tastenkürzel"
+  },
+  "options_execute_action": {
+    "message": "Aktion ausführen"
+  },
+  "options_toggle_debug": {
+    "message": "Debuggen umschalten"
+  },
+  "options_toggle_profile": {
+    "message": "Profilierung umschalten"
+  },
+  "options_toggle_trace": {
+    "message": "Tracing umschalten"
+  },
+  "popup_title": {
+    "message": "Xdebug Helper-Popup"
+  },
+  "popup_debug": {
+    "message": "Debuggen"
+  },
+  "popup_profile": {
+    "message": "Profilierung"
+  },
+  "popup_trace": {
+    "message": "Tracing"
+  },
+  "popup_disable": {
+    "message": "Deaktivieren"
+  },
+  "popup_options": {
+    "message": "Optionen"
+  }
+}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper by JetBrains"
+  },
+  "options_title": {
+    "message": "Xdebug Helper Options"
+  },
+  "options_debug_trigger": {
+    "message": "Debug Trigger or Xdebug Cloud Key"
+  },
+  "options_trace_trigger": {
+    "message": "Trace Trigger"
+  },
+  "options_profile_trigger": {
+    "message": "Profile Trigger"
+  },
+  "options_clear": {
+    "message": "Clear"
+  },
+  "options_save": {
+    "message": "Save"
+  },
+  "options_shortcuts": {
+    "message": "Shortcuts"
+  },
+  "options_execute_action": {
+    "message": "Execute action"
+  },
+  "options_toggle_debug": {
+    "message": "Toggle debugging"
+  },
+  "options_toggle_profile": {
+    "message": "Toggle profiling"
+  },
+  "options_toggle_trace": {
+    "message": "Toggle tracing"
+  },
+  "popup_title": {
+    "message": "Xdebug Helper Popup"
+  },
+  "popup_debug": {
+    "message": "Debug"
+  },
+  "popup_profile": {
+    "message": "Profile"
+  },
+  "popup_trace": {
+    "message": "Trace"
+  },  
+  "popup_disable": {
+    "message": "Disable"
+  },
+  "popup_options": {
+    "message": "options"
+  }
+}

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper de JetBrains"
+  },
+  "options_title": {
+    "message": "Opciones de Xdebug Helper"
+  },
+  "options_debug_trigger": {
+    "message": "Desencadenador de Depuración o Clave de Xdebug Cloud"
+  },
+  "options_trace_trigger": {
+    "message": "Desencadenador de Rastreo"
+  },
+  "options_profile_trigger": {
+    "message": "Desencadenador de Perfilado"
+  },
+  "options_clear": {
+    "message": "Limpiar"
+  },
+  "options_save": {
+    "message": "Guardar"
+  },
+  "options_shortcuts": {
+    "message": "Atajos"
+  },
+  "options_execute_action": {
+    "message": "Ejecutar acción"
+  },
+  "options_toggle_debug": {
+    "message": "Alternar depuración"
+  },
+  "options_toggle_profile": {
+    "message": "Alternar perfilado"
+  },
+  "options_toggle_trace": {
+    "message": "Alternar rastreo"
+  },
+  "popup_title": {
+    "message": "Ventana emergente de Xdebug Helper"
+  },
+  "popup_debug": {
+    "message": "Depurar"
+  },
+  "popup_profile": {
+    "message": "Perfilado"
+  },
+  "popup_trace": {
+    "message": "Rastreo"
+  },
+  "popup_disable": {
+    "message": "Desactivar"
+  },
+  "popup_options": {
+    "message": "Opciones"
+  }
+}

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper par JetBrains"
+  },
+  "options_title": {
+    "message": "Options de Xdebug Helper"
+  },
+  "options_debug_trigger": {
+    "message": "Déclencheur de débogage ou clé Xdebug Cloud"
+  },
+  "options_trace_trigger": {
+    "message": "Déclencheur de traçage"
+  },
+  "options_profile_trigger": {
+    "message": "Déclencheur de profilage"
+  },
+  "options_clear": {
+    "message": "Effacer"
+  },
+  "options_save": {
+    "message": "Enregistrer"
+  },
+  "options_shortcuts": {
+    "message": "Raccourcis"
+  },
+  "options_execute_action": {
+    "message": "Exécuter l'action"
+  },
+  "options_toggle_debug": {
+    "message": "Activer/désactiver le débogage"
+  },
+  "options_toggle_profile": {
+    "message": "Activer/désactiver le profilage"
+  },
+  "options_toggle_trace": {
+    "message": "Activer/désactiver le traçage"
+  },
+  "popup_title": {
+    "message": "Fenêtre contextuelle de Xdebug Helper"
+  },
+  "popup_debug": {
+    "message": "Déboguer"
+  },
+  "popup_profile": {
+    "message": "Profilage"
+  },
+  "popup_trace": {
+    "message": "Traçage"
+  },
+  "popup_disable": {
+    "message": "Désactiver"
+  },
+  "popup_options": {
+    "message": "Options"
+  }
+}

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug Helper от JetBrains"
+  },
+  "options_title": {
+    "message": "Параметры Xdebug Helper"
+  },
+  "options_debug_trigger": {
+    "message": "Триггер отладки или ключ Xdebug Cloud"
+  },
+  "options_trace_trigger": {
+    "message": "Триггер трассировки"
+  },
+  "options_profile_trigger": {
+    "message": "Триггер профилирования"
+  },
+  "options_clear": {
+    "message": "Очистить"
+  },
+  "options_save": {
+    "message": "Сохранить"
+  },
+  "options_shortcuts": {
+    "message": "Сочетания клавиш"
+  },
+  "options_execute_action": {
+    "message": "Выполнить действие"
+  },
+  "options_toggle_debug": {
+    "message": "Переключить отладку"
+  },
+  "options_toggle_profile": {
+    "message": "Переключить профилирование"
+  },
+  "options_toggle_trace": {
+    "message": "Переключить трассировку"
+  },
+  "popup_title": {
+    "message": "Всплывающее окно Xdebug Helper"
+  },
+  "popup_debug": {
+    "message": "Отладка"
+  },
+  "popup_profile": {
+    "message": "Профилирование"
+  },
+  "popup_trace": {
+    "message": "Трассировка"
+  },
+  "popup_disable": {
+    "message": "Отключить"
+  },
+  "popup_options": {
+    "message": "Параметры"
+  }
+}

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -1,0 +1,56 @@
+{
+  "extension_name": {
+    "message": "Xdebug 助手 (由 JetBrains 提供)"
+  },
+  "options_title": {
+    "message": "Xdebug 助手选项"
+  },
+  "options_debug_trigger": {
+    "message": "调试触发器或 Xdebug 云密钥"
+  },
+  "options_trace_trigger": {
+    "message": "跟踪触发器"
+  },
+  "options_profile_trigger": {
+    "message": "性能分析触发器"
+  },
+  "options_clear": {
+    "message": "清除"
+  },
+  "options_save": {
+    "message": "保存"
+  },
+  "options_shortcuts": {
+    "message": "快捷键"
+  },
+  "options_execute_action": {
+    "message": "执行操作"
+  },
+  "options_toggle_debug": {
+    "message": "切换调试"
+  },
+  "options_toggle_profile": {
+    "message": "切换性能分析"
+  },
+  "options_toggle_trace": {
+    "message": "切换跟踪"
+  },
+  "popup_title": {
+    "message": "Xdebug 助手弹出窗口"
+  },
+  "popup_debug": {
+    "message": "调试"
+  },
+  "popup_profile": {
+    "message": "性能分析"
+  },
+  "popup_trace": {
+    "message": "跟踪"
+  },
+  "popup_disable": {
+    "message": "禁用"
+  },
+  "popup_options": {
+    "message": "选项"
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,7 @@
     "version": "1.0.3",
     "description": "A modern, dependency-free, extension for Xdebug",
     "author": "fraser.chapman@gmail.com",
+    "default_locale": "en",
     "permissions": [
         "storage",
         "activeTab"
@@ -37,21 +38,21 @@
                 "default": "Alt+C",
                 "mac": "Alt+C"
             },
-            "description": "Toggle debugging"
+            "description": "__MSG_options_toggle_debug__"
         },
         "run-toggle-profile": {
             "suggested_key": {
                 "default": "Alt+V",
                 "mac": "Alt+V"
             },
-            "description": "Toggle profiling"
+            "description": "__MSG_options_toggle_profile__"
         },
         "run-toggle-trace": {
             "suggested_key": {
                 "default": "Alt+B",
                 "mac": "Alt+B"
             },
-            "description": "Toggle tracing"
+            "description": "__MSG_options_toggle_trace__"
         },
         "_execute_action": {
             "suggested_key": {

--- a/src/options.html
+++ b/src/options.html
@@ -4,27 +4,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xdebug Helper Options</title>
+    <title data-locale="options_title">Xdebug Helper Options</title>
     <link rel="stylesheet" type="text/css" href="options.css">
 </head>
 
 <body>
-    <h1>Xdebug Helper by JetBrains</h1>
+    <h1 data-locale="extension_name">Xdebug Helper by JetBrains</h1>
     <form>
         <fieldset>
-            <legend>Options</legend>
-            <label for="debugtrigger">Debug Trigger or Xdebug Cloud Key</label>
-            <input type="text" id="debugtrigger" placeholder="Debug trigger or Xdebug Cloud Key" value="YOUR-NAME">
-            <label for="tracetrigger">Trace Trigger</label>
+            <label for="debugtrigger" data-locale="options_debug_trigger">Debug Trigger or Xdebug Cloud Key</label>
+            <input type="text" id="debugtrigger" placeholder="YOUR-NAME" value="">
+            <label for="tracetrigger" data-locale="options_trace_trigger">Trace Trigger</label>
             <input type="text" id="tracetrigger" placeholder="Trace trigger" value="">
-            <label for="profiletrigger">Profile Trigger</label>
+            <label for="profiletrigger" data-locale="options_profile_trigger">Profile Trigger</label>
             <input type="text" id="profiletrigger" placeholder="Profile trigger" value="">
-            <button type="reset">Clear</button>
-            <button type="submit">Save</button>
+            <button type="reset" data-locale="options_clear">Clear</button>
+            <button type="submit" data-locale="options_save">Save</button>
         </fieldset>
     </form>
     <div id="help">
-        <h2>Shortcuts</h2>
+        <h2 data-locale="options_shortcuts">Shortcuts</h2>
     </div>
     <a href="https://github.com/JetBrains/xdebug-extension" target="_blank">
         <img src="img/github25.png" alt="GitHub logo" width="25" height="25">

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const profileTriggerInput = document.getElementById('profiletrigger');
     const helpDiv = document.getElementById('help');
 
+    document.querySelectorAll('[data-locale]').forEach(e => {
+        e.innerText = chrome.i18n.getMessage(e.dataset.locale)
+    });
+
     document.querySelector('button[type="reset"]').addEventListener('click', e => {
         e.preventDefault();
         debugTriggerInput.value = '';
@@ -43,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        for (const { name, shortcut } of commands) {
+        for (const { name, shortcut , description } of commands) {    
             if (!shortcut) {
                 break;
             }
@@ -58,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
-            newP.appendChild(document.createTextNode(name.replace(/_|-|run/g, ' ')));
+            newP.appendChild(document.createTextNode(' ' + (description || chrome.i18n.getMessage("options_execute_action"))));
             helpDiv.appendChild(newP);
         }
     });

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,21 +4,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xdebug Helper Popup</title>
+    <title data-locale="popup_title">Xdebug Helper Popup</title>
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 
 <body>
     <form id="popup">
         <input type="radio" id="debug" name="state" value="1">
-        <label for="debug"><img src="img/debug16.png" />Debug</label>
+        <label for="debug" data-locale="popup_debug"><img src="img/debug16.png" />Debug</label>
         <input type="radio" id="profile" name="state" value="2">
-        <label for="profile"><img src="img/profile16.png" />Profile</label>
+        <label for="profile" data-locale="popup_profile"><img src="img/profile16.png" />Profile</label>
         <input type="radio" id="trace" name="state" value="3">
-        <label for="trace"><img src="img/trace16.png" />Trace</label>
+        <label for="trace" data-locale="popup_trace"><img src="img/trace16.png" />Trace</label>
         <input type="radio" id="disable" name="state" value="0">
-        <label for="disable"><img src="img/disable16.png" />Disable</label>
-        <a href="#" id="options">options</a>
+        <label for="disable" data-locale="popup_disable"><img src="img/disable16.png" />Disable</label>
+        <a href="#" id="options" data-locale="popup_options">options</a>
     </form>
     <script src="popup.js"></script>
 </body>

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,6 +2,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     const radioButtons = document.querySelectorAll('input[name="state"]');
     const optionsLink = document.querySelector('#options');
 
+    document.querySelectorAll('[data-locale]').forEach(e => {
+        const message = chrome.i18n.getMessage(e.dataset.locale);
+        const lastNode = e.childNodes[e.childNodes.length - 1];
+        if (lastNode.nodeType === Node.TEXT_NODE) {
+            lastNode.textContent = message;
+        } else if (e.childNodes.length === 0){
+            e.innerText = message;
+        }
+    });
+
     try {
         const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
         if (!tab) {


### PR DESCRIPTION
Uses the chrome.i18n infrastructure to implement internationalisation for the extension.

See https://developer.chrome.com/docs/extensions/reference/api/i18n

Initially adds support for

- cs | Czech
- de | German
- en | English
- es | Spanish
- fr | French
- ru | Russian
- zh | Chinese

e.g. 

Spanish 

![Screenshot 2025-03-13 002618](https://github.com/user-attachments/assets/5239c696-4a93-4649-8cc1-2e0f0d487885)
![Screenshot 2025-03-13 002635](https://github.com/user-attachments/assets/7179be99-1507-4a19-aed8-01728669e589)

Czech

![Screenshot 2025-03-13 002852](https://github.com/user-attachments/assets/278cdd08-0b29-4365-aa5a-8a66674bdcc5)
![Screenshot 2025-03-13 002907](https://github.com/user-attachments/assets/5949bf6f-e040-4078-aebd-04451770b90e)

etc.

Would be trivial to add/support other languages using this setup. 