### PR TITLE
add help link to options for custom-shortcuts

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -105,7 +105,7 @@ kbd {
 }
 
 a {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   text-decoration: none;
   transition: color 0.3s ease;
@@ -125,6 +125,28 @@ a img {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease, color 0.3s ease;
   background: var(--light-form-bg);
+}
+
+#help a {
+  position: relative;
+}
+
+#help a::before {
+  content: '?';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-125%);
+  width: 1.8ex;
+  height: 1.8ex;
+  font-size: 1.2ex;
+  line-height: 1.8ex;
+  border-radius: 1.2ex;
+  padding: 1px;
+  color: var(--input-focus-border);
+  background: white;
+  border: 1px solid var(--input-focus-border);
+  text-align: center;
 }
 
 button[type="submit"] {

--- a/src/options.html
+++ b/src/options.html
@@ -23,7 +23,9 @@
         </fieldset>
     </form>
     <div id="help">
-        <h2 data-locale="options_shortcuts">Shortcuts</h2>
+        <h2><span data-locale="options_shortcuts">Shortcuts</span> <a
+                href="https://github.com/JetBrains/xdebug-extension?tab=readme-ov-file#custom-shortcuts"
+                target="_blank"></a></h2>
     </div>
     <a href="https://github.com/JetBrains/xdebug-extension" target="_blank">
         <img src="img/github25.png" alt="GitHub logo" width="25" height="25">


### PR DESCRIPTION
See https://github.com/JetBrains/xdebug-extension/issues/25 and https://github.com/JetBrains/xdebug-extension/issues/21 and https://github.com/JetBrains/xdebug-extension/issues/12 and https://github.com/JetBrains/xdebug-extension/issues/27 and https://github.com/JetBrains/xdebug-extension/issues/36

A few users have had issues where they think the shortcuts are not configurable or optional - this just adds a (?) link to https://github.com/JetBrains/xdebug-extension?tab=readme-ov-file#custom-shortcuts in the options page to hopefully make it clearer, e.g.

![Screenshot 2025-04-16 141036](https://github.com/user-attachments/assets/23530c04-77a3-474e-b9f4-d297a32aa9ea)
