### PR TITLE
Translated labels overflow the options menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /test/node_modules
+.idea

--- a/src/popup.css
+++ b/src/popup.css
@@ -15,7 +15,8 @@
 
 body {
   font-family: Arial, sans-serif;
-  width: 100px;
+  width: max-content;
+  min-width: 100px;
   font-size: 0.8em;
   color: var(--light-text);
 }
@@ -23,7 +24,7 @@ body {
 form {
   display: flex;
   flex-direction: column;
-  width: 100px;
+  width: 100%;
   gap: 0.2em;
 }
 


### PR DESCRIPTION
Fix text overflow in popup for longer translations

Updates the popup CSS to use a dynamic width (`max-content`) instead of a hardcoded `100px`. This ensures the extension menu correctly resizes to fit longer i18n strings, such as those in the German locale, without the text breaking out of the container.

See https://github.com/JetBrains/xdebug-extension/issues/48

Before 

<img width="128" height="182" alt="image" src="https://github.com/user-attachments/assets/ed83e91d-418c-4821-a0b7-ac5e8dccc543" />


After

<img width="149" height="191" alt="image" src="https://github.com/user-attachments/assets/024509df-9df9-47f4-b290-43d38ce64b66" />
